### PR TITLE
blog Ensuring Terraform State Security with Ephemeral Values and Writ…

### DIFF
--- a/Terraform-Ephemeral-Values/README.md
+++ b/Terraform-Ephemeral-Values/README.md
@@ -1,0 +1,7 @@
+## How to use If-Else in Terraform
+
+Ephemeral resources are Terraform resources that are essentially temporary. Ephemeral resources have a unique lifecycle, and Terraform does not store information about ephemeral resources in state or plan files. Each ephemeral block describes one or more ephemeral resources, such as a temporary password or connection to another system. (you must use Terraform v.1.11 or later and use a resource that supports write-only arguments)
+
+In this blog post, I will cover what are ephmeral resources, why write-only arguments should be used and an example both being used in Azure to store and retrieve sensitive values without them being stored in the state file.
+
+[Blog post here](https://thomasthornton.cloud/2023/10/16/how-to-use-if-else-in-terraform/)

--- a/Terraform-Ephemeral-Values/terraform/main.tf
+++ b/Terraform-Ephemeral-Values/terraform/main.tf
@@ -1,0 +1,57 @@
+resource "azurerm_resource_group" "tamops-rg" {
+  name     = "tamops-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_key_vault" "tamops-kv" {
+  name                       = "tamops-keyvault"
+  location                   = azurerm_resource_group.tamops-rg.location
+  resource_group_name        = azurerm_resource_group.tamops-rg.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "standard"
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions = [
+      "Create",
+      "Get",
+    ]
+
+    secret_permissions = [
+      "Set",
+      "Get",
+        "List",
+      "Delete",
+      "Purge",
+      "Recover"
+    ]
+  }
+}
+
+resource "azurerm_key_vault_secret" "tamops-secret" {
+  name         = "secret-password"
+  value_wo        = "secret-password-value"
+  value_wo_version = "3"
+  key_vault_id = azurerm_key_vault.tamops-kv.id
+}
+
+ephemeral "azurerm_key_vault_secret" "tamops-secret" {
+  name         = azurerm_key_vault_secret.tamops-secret.name
+  key_vault_id = azurerm_key_vault.tamops-kv.id
+}
+
+resource "azurerm_key_vault_secret" "tamops-secret2" {
+  name         = "secret-password4"
+  value_wo        = ephemeral.azurerm_key_vault_secret.tamops-secret.value
+  value_wo_version = "1"
+  key_vault_id = azurerm_key_vault.tamops-kv.id
+}
+
+
+resource "azurerm_key_vault_secret" "tamops-secret" {
+  name         = "secret-password"
+  value        = "secret-password-value"
+  key_vault_id = azurerm_key_vault.tamops-kv.id
+}

--- a/Terraform-Ephemeral-Values/terraform/providers.tf
+++ b/Terraform-Ephemeral-Values/terraform/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  backend "local" {
+  }
+}
+
+provider "azurerm" {
+  features {}
+  subscription_id = "04109105-f3ca-44ac-a3a7-66b4936112c3"
+}
+
+data "azurerm_client_config" "current" {}


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Adds example code demonstrating Terraform's ephemeral resources and write-only outputs for secure handling of sensitive values in Azure Key Vault.

- Created a new example directory `Terraform-Ephemeral-Values` with documentation explaining ephemeral resources and write-only arguments in Terraform.
- Implemented Azure Key Vault configuration in `main.tf` showcasing how to use `value_wo` attributes and `ephemeral` blocks to handle sensitive data securely.
- Demonstrated a practical pattern for retrieving and using sensitive values without exposing them in Terraform state files.
- Added provider configuration for Azure with local backend setup to complete the working example.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->

…e-Only Outputs